### PR TITLE
Add initial setup scripts for RHEL with Docker configuration

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+# EditorConfig is awesome: https://EditorConfig.org
+
+# top-most EditorConfig file
+root = true
+
+[*]
+indent_style = space
+indent_size = 2
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = false
+insert_final_newline = false

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+.vscode/*
+!.vscode/settings.json
+!.vscode/tasks.json
+!.vscode/launch.json
+!.vscode/extensions.json
+!.vscode/*.code-snippets
+!*.code-workspace
+
+# Built Visual Studio Code Extensions
+*.vsix

--- a/README.md
+++ b/README.md
@@ -1,1 +1,96 @@
-# shell-scripts
+# server-shell-scripts
+
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
+A collection of shell scripts for provisioning and configuring Red Hat Enterprise Linux (RHEL) servers. These scripts automate common setup tasks such as installing Docker CE and enabling automatic system updates.
+
+## Table of Contents
+
+- [Prerequisites](#prerequisites)
+- [Quick Start](#quick-start)
+- [Scripts](#scripts)
+  - [setup-docker.sh](#setup-dockersh)
+  - [setup-dnf-automatic.sh](#setup-dnf-automaticsh)
+- [Notes](#notes)
+- [License](#license)
+
+## Prerequisites
+
+- RHEL 8/9 or a compatible distribution (Rocky Linux, AlmaLinux, etc.)
+- `sudo` or root access
+- `dnf` package manager
+
+## Quick Start
+
+Run a script directly from the repository without cloning it first:
+
+```bash
+# Install Docker CE
+curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-docker.sh | sudo bash
+
+# Configure automatic system updates
+curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-dnf-automatic.sh | sudo bash
+```
+
+> **Tip:** Review the script contents before piping to a shell — visit the raw URL in a browser or run `curl -fsSL <url>` without `| sudo bash` first.
+
+## Scripts
+
+### setup-docker.sh
+
+**Location:** `scripts/rhel/setup-docker.sh`
+
+Installs Docker CE and related tooling on a RHEL system with a production-ready daemon configuration.
+
+**What it does:**
+
+- Updates and upgrades all system packages via `dnf`
+- Adds Docker's official RHEL repository
+- Installs `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, and `docker-compose-plugin`
+- Enables and starts the Docker systemd service
+- Creates the `docker` group and adds the current user to it
+- Installs `container-selinux` for SELinux compatibility
+- Writes `/etc/docker/daemon.json` with:
+  - `systemd` cgroup driver
+  - JSON file logging with 10 MB max size and 3-file rotation
+- Reloads systemd and restarts Docker
+- Validates the installation by running the `hello-world` container
+
+**Usage:**
+
+```bash
+sudo bash scripts/rhel/setup-docker.sh
+```
+
+---
+
+### setup-dnf-automatic.sh
+
+**Location:** `scripts/rhel/setup-dnf-automatic.sh`
+
+Configures unattended daily system updates using `dnf-automatic`.
+
+**What it does:**
+
+- Updates and upgrades all system packages via `dnf`
+- Installs the `dnf-automatic` package
+- Configures `/etc/dnf/automatic.conf`:
+  - `upgrade_type = default` — applies all available updates
+  - `apply_updates = yes` — updates are applied automatically without manual intervention
+- Enables and starts the `dnf-automatic.timer` systemd unit to run daily
+
+**Usage:**
+
+```bash
+sudo bash scripts/rhel/setup-dnf-automatic.sh
+```
+
+## Notes
+
+- **Both scripts are independent and complementary.** Run both to get a fully configured Docker host with automatic system updates.
+- **Docker group membership** — `setup-docker.sh` adds the current user to the `docker` group so Docker commands can be run without `sudo`. You may need to log out and back in for this to take effect in new terminal sessions.
+- **System update on every run** — both scripts begin with a full `dnf update && dnf upgrade`, so they may take several minutes on a freshly provisioned system.
+
+## License
+
+[MIT](LICENSE) © Patrick Quijano

--- a/scripts/rhel/setup-dnf-automatic.sh
+++ b/scripts/rhel/setup-dnf-automatic.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# Update and upgrade the system
+sudo dnf -y update
+sudo dnf -y upgrade
+
+# Install dnf-automatic for automatic updates and configure it to apply updates automatically
+sudo dnf -y install dnf-automatic
+sudo sed -i 's/^upgrade_type = .*/upgrade_type = default/' /etc/dnf/automatic.conf
+sudo sed -i 's/^apply_updates = .*/apply_updates = yes/' /etc/dnf/automatic.conf
+
+# Enable and start the dnf-automatic timer to run daily
+sudo systemctl enable --now dnf-automatic.timer

--- a/scripts/rhel/setup-docker.sh
+++ b/scripts/rhel/setup-docker.sh
@@ -12,14 +12,6 @@ sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin d
 # Enable and start the Docker service
 sudo systemctl enable --now docker
 
-# Install dnf-automatic for automatic updates and configure it to apply updates automatically
-sudo dnf -y install dnf-automatic
-sudo sed -i 's/^upgrade_type = .*/upgrade_type = default/' /etc/dnf/automatic.conf
-sudo sed -i 's/^apply_updates = .*/apply_updates = yes/' /etc/dnf/automatic.conf
-
-# Enable and start the dnf-automatic timer to run daily
-sudo systemctl enable --now dnf-automatic.timer
-
 # Add the azureuser to the docker group to run Docker without sudo
 if ! getent group docker; then
   sudo groupadd docker
@@ -27,6 +19,9 @@ fi
 
 # Add the current user to the docker group
 sudo usermod -aG docker $USER
+
+# Apply the new group membership without logging out
+newgrp docker
 
 # Install SELinux policy for Docker
 sudo dnf -y install container-selinux

--- a/scripts/rhel/setup-docker.sh
+++ b/scripts/rhel/setup-docker.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# Update and upgrade the system
+sudo dnf -y update
+sudo dnf -y upgrade
+
+# Install Docker CE and dependencies
+sudo dnf -y install dnf-plugins-core
+sudo dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
+sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Enable and start the Docker service
+sudo systemctl enable --now docker
+
+# Install dnf-automatic for automatic updates and configure it to apply updates automatically
+sudo dnf -y install dnf-automatic
+sudo sed -i 's/^upgrade_type = .*/upgrade_type = default/' /etc/dnf/automatic.conf
+sudo sed -i 's/^apply_updates = .*/apply_updates = yes/' /etc/dnf/automatic.conf
+
+# Enable and start the dnf-automatic timer to run daily
+sudo systemctl enable --now dnf-automatic.timer
+
+# Add the azureuser to the docker group to run Docker without sudo
+if ! getent group docker; then
+  sudo groupadd docker
+fi
+
+# Add the current user to the docker group
+sudo usermod -aG docker $USER
+
+# Install SELinux policy for Docker
+sudo dnf -y install container-selinux
+
+# Configure Docker daemon to use systemd as the cgroup driver and set log options
+sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+  "exec-opts": [
+    "native.cgroupdriver=systemd"
+  ],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+EOF
+
+# Reload systemd and restart Docker to apply the new configuration
+sudo systemctl daemon-reload
+sudo systemctl restart docker
+
+# Test Docker installation by running the hello-world container
+docker run --rm hello-world || echo "Docker hello-world test failed"


### PR DESCRIPTION
Introduce initial setup scripts for provisioning RHEL servers, focusing on Docker installation and configuration. Remove the dnf-automatic setup from the Docker script and provide detailed documentation in the README for better user guidance.