### PR TITLE
Update setup-docker.sh to accept user argument for Docker group membership

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,10 @@ A collection of shell scripts for provisioning and configuring Red Hat Enterpris
 Run a script directly from the repository without cloning it first:
 
 ```bash
-# Install Docker CE
-curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-docker.sh | sudo bash
+curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-docker.sh | sudo bash -s -- <username>
+```
 
-# Configure automatic system updates
+```bash
 curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-dnf-automatic.sh | sudo bash
 ```
 
@@ -44,22 +44,23 @@ Installs Docker CE and related tooling on a RHEL system with a production-ready 
 
 **What it does:**
 
+- Validates that a `<username>` argument is provided and that the user exists on the system
 - Updates and upgrades all system packages via `dnf`
-- Adds Docker's official RHEL repository
-- Installs `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, and `docker-compose-plugin`
-- Enables and starts the Docker systemd service
-- Creates the `docker` group and adds the current user to it
-- Installs `container-selinux` for SELinux compatibility
-- Writes `/etc/docker/daemon.json` with:
+- Installs `dnf-plugins-core` and adds Docker's official RHEL repository
+- Installs `docker-ce`, `docker-ce-cli`, `containerd.io`, `docker-buildx-plugin`, `docker-compose-plugin`, and `container-selinux`
+- Creates the `docker` group if it does not already exist, and adds the specified user to it
+- Writes `/etc/docker/daemon.json` — prompts before overwriting if the file already exists — with:
   - `systemd` cgroup driver
   - JSON file logging with 10 MB max size and 3-file rotation
-- Reloads systemd and restarts Docker
-- Validates the installation by running the `hello-world` container
+- Enables and starts the `docker` systemd service if it is not already running
+- Enables and starts the `containerd` systemd service if it is not already running
 
 **Usage:**
 
 ```bash
-sudo bash scripts/rhel/setup-docker.sh
+sudo bash scripts/rhel/setup-docker.sh <username>
+# Example:
+sudo bash scripts/rhel/setup-docker.sh azureuser
 ```
 
 ---
@@ -88,7 +89,8 @@ sudo bash scripts/rhel/setup-dnf-automatic.sh
 ## Notes
 
 - **Both scripts are independent and complementary.** Run both to get a fully configured Docker host with automatic system updates.
-- **Docker group membership** — `setup-docker.sh` adds the current user to the `docker` group so Docker commands can be run without `sudo`. You may need to log out and back in for this to take effect in new terminal sessions.
+- **Docker group membership** — `setup-docker.sh` accepts a required `<username>` argument and adds that user to the `docker` group so Docker commands can be run without `sudo`. You may need to log out and back in for this to take effect in new terminal sessions.
+- **daemon.json prompt** — if `/etc/docker/daemon.json` already exists when `setup-docker.sh` is run, the script will display the current contents and ask whether to overwrite it. Answering `N` skips the update and leaves the existing configuration in place.
 - **System update on every run** — both scripts begin with a full `dnf update && dnf upgrade`, so they may take several minutes on a freshly provisioned system.
 
 ## License

--- a/scripts/rhel/setup-docker.sh
+++ b/scripts/rhel/setup-docker.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
+# This script sets up Docker CE on RHEL-based systems, adds the specified user to the docker group,and configures the Docker daemon to use systemd as the cgroup driver with log rotation options.
+# Usage: ./setup-docker.sh <username>
+
+set -e
+
+# Check if a username argument is provided
+if [[ $# -lt 1 ]]; then
+  echo "Usage: $(basename "$0") <username>"
+  echo "  username  The system user to add to the docker group"
+  exit 1
+fi
+
+# Get the target user from the command line argument
+TARGET_USER="$1"
+
+# Check if the specified user exists
+if ! id "$TARGET_USER" &>/dev/null; then
+  echo "Error: user '$TARGET_USER' does not exist"
+  exit 1
+fi
 
 # Update and upgrade the system
 sudo dnf -y update
@@ -9,16 +29,23 @@ sudo dnf -y install dnf-plugins-core
 sudo dnf config-manager --add-repo https://download.docker.com/linux/rhel/docker-ce.repo
 sudo dnf -y install docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin container-selinux
 
-# Add the azureuser to the docker group to run Docker without sudo
+# Add the docker group if it does not exist
 if ! getent group docker; then
   sudo groupadd docker
 fi
 
-# Add the current user to the docker group
-sudo usermod -aG docker $USER
+# Add the specified user to the docker group
+sudo usermod -aG docker "$TARGET_USER"
 
-# Configure Docker daemon to use systemd as the cgroup driver and set log options
-sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+# Configure Docker daemon to use systemd as the cgroup driver and set log rotation options
+if [[ -f /etc/docker/daemon.json ]]; then
+  echo "Existing /etc/docker/daemon.json found:"
+  cat /etc/docker/daemon.json
+  read -rp "Replace existing daemon.json? [y/N] " reply
+  if [[ ! "$reply" =~ ^[Yy]$ ]]; then
+    echo "Skipping daemon.json update"
+  else
+    sudo tee /etc/docker/daemon.json > /dev/null <<EOF
 {
   "exec-opts": [
     "native.cgroupdriver=systemd"
@@ -30,13 +57,33 @@ sudo tee /etc/docker/daemon.json > /dev/null <<EOF
   }
 }
 EOF
+  fi
+else
+  sudo tee /etc/docker/daemon.json > /dev/null <<EOF
+{
+  "exec-opts": [
+    "native.cgroupdriver=systemd"
+  ],
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+EOF
+fi
 
-# Enable and start Docker and containerd services
-sudo systemctl enable --now docker
-sudo systemctl enable --now containerd
+# Enable and start the Docker and containerd services
+if sudo systemctl is-active --quiet docker; then
+  echo "Docker service is already running"
+else
+  sudo systemctl enable --now docker
+  echo "Docker service enabled and running"
+fi
 
-# Apply the new group membership without logging out
-newgrp docker
-
-# Test Docker installation by running the hello-world container
-docker run --rm hello-world || echo "Docker hello-world test failed"
+if sudo systemctl is-active --quiet containerd; then
+  echo "containerd service is already running"
+else
+  sudo systemctl enable --now containerd
+  echo "containerd service enabled and running"
+fi


### PR DESCRIPTION
Modify the setup-docker.sh script to require a username argument for adding a user to the Docker group. This change enhances usability by allowing the specification of any user instead of defaulting to the current user. The script also includes validation for the provided username and prompts before overwriting the existing Docker daemon configuration.