### PR TITLE
Add automated disk management scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ A collection of shell scripts for provisioning and configuring Red Hat Enterpris
 - [Scripts](#scripts)
   - [setup-docker.sh](#setup-dockersh)
   - [setup-dnf-automatic.sh](#setup-dnf-automaticsh)
-  - [setup-disk.sh](#setup-disksh)
+  - [setup-new-disk.sh](#setup-new-disksh)
+  - [setup-existing-disk.sh](#setup-existing-disksh)
 - [Notes](#notes)
 - [License](#license)
 
@@ -87,9 +88,9 @@ sudo bash scripts/rhel/setup-dnf-automatic.sh
 
 ---
 
-### setup-disk.sh
+### setup-new-disk.sh
 
-**Location:** `scripts/rhel/setup-disk.sh`
+**Location:** `scripts/rhel/setup-new-disk.sh`
 
 Identifies unpartitioned disks, prompts to select one, creates a single XFS partition on a GPT partition table, mounts it at a user-specified path, and writes a UUID-based `/etc/fstab` entry so the mount persists across reboots.
 
@@ -107,14 +108,45 @@ Identifies unpartitioned disks, prompts to select one, creates a single XFS part
 **Usage:**
 
 ```bash
-sudo sh scripts/rhel/setup-disk.sh
+sudo sh scripts/rhel/setup-new-disk.sh
 ```
 
 > **Note:** This script is fully interactive — it reads from the terminal. Piping it from `curl` will break the prompts. Download it first, then run it:
 >
 > ```bash
-> curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-disk.sh -o /tmp/setup-disk.sh
-> sudo sh /tmp/setup-disk.sh
+> curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-new-disk.sh -o /tmp/setup-new-disk.sh
+> sudo sh /tmp/setup-new-disk.sh
+> ```
+
+---
+
+### setup-existing-disk.sh
+
+**Location:** `scripts/rhel/setup-existing-disk.sh`
+
+Identifies existing partitions that already have filesystems but are not currently mounted, prompts to select one, mounts it at a user-specified path, and writes a UUID-based `/etc/fstab` entry so the mount persists across reboots.
+
+**What it does:**
+
+- Detects unmounted partitions where a filesystem already exists (no partitioning or formatting)
+- Prompts to select one partition and validates the input
+- Prompts for an absolute mount point path and validates it is not already in use
+- Aborts if `/etc/fstab` already contains an entry for the selected partition UUID, device path, or mount point
+- Displays a summary and requires explicit `[y/N]` confirmation before mounting
+- Creates the mount point directory, mounts the partition, and appends a UUID-based entry to `/etc/fstab`
+- Displays `lsblk`, `df -h`, and the fstab entry to confirm success
+
+**Usage:**
+
+```bash
+sudo sh scripts/rhel/setup-existing-disk.sh
+```
+
+> **Note:** This script is fully interactive — it reads from the terminal. Piping it from `curl` will break the prompts. Download it first, then run it:
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-existing-disk.sh -o /tmp/setup-existing-disk.sh
+> sudo sh /tmp/setup-existing-disk.sh
 > ```
 
 ## Notes

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A collection of shell scripts for provisioning and configuring Red Hat Enterpris
 - [Scripts](#scripts)
   - [setup-docker.sh](#setup-dockersh)
   - [setup-dnf-automatic.sh](#setup-dnf-automaticsh)
+  - [setup-disk.sh](#setup-disksh)
 - [Notes](#notes)
 - [License](#license)
 
@@ -83,6 +84,38 @@ Configures unattended daily system updates using `dnf-automatic`.
 ```bash
 sudo bash scripts/rhel/setup-dnf-automatic.sh
 ```
+
+---
+
+### setup-disk.sh
+
+**Location:** `scripts/rhel/setup-disk.sh`
+
+Identifies unpartitioned disks, prompts to select one, creates a single XFS partition on a GPT partition table, mounts it at a user-specified path, and writes a UUID-based `/etc/fstab` entry so the mount persists across reboots.
+
+**What it does:**
+
+- Detects block devices with no existing partitions and presents them in a numbered list
+- Prompts to select a disk and validates the input
+- Prompts for an absolute mount point path and validates it is not already in use
+- Displays a summary and requires explicit `[y/N]` confirmation before any disk changes
+- Creates a GPT partition table and a single data partition (1 MiB aligned, full disk)
+- Formats the partition with XFS using `mkfs.xfs`
+- Creates the mount point directory, mounts the partition, and appends a UUID-based entry to `/etc/fstab`
+- Displays `lsblk`, `df -h`, and the fstab entry to confirm success
+
+**Usage:**
+
+```bash
+sudo sh scripts/rhel/setup-disk.sh
+```
+
+> **Note:** This script is fully interactive — it reads from the terminal. Piping it from `curl` will break the prompts. Download it first, then run it:
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-disk.sh -o /tmp/setup-disk.sh
+> sudo sh /tmp/setup-disk.sh
+> ```
 
 ## Notes
 

--- a/scripts/rhel/setup-disk.sh
+++ b/scripts/rhel/setup-disk.sh
@@ -1,0 +1,139 @@
+#!/bin/sh
+# Prompts to select an unpartitioned disk, creates a GPT partition with XFS
+# filesystem, mounts it at a user-specified path, and adds a fstab entry for
+# persistence across reboots.
+# Usage: sudo sh setup-disk.sh
+
+set -e
+
+# Create a temporary file to store the list of unpartitioned disks
+DISK_LIST=$(mktemp)
+trap 'rm -f "$DISK_LIST"' EXIT
+
+# List all block devices, filter for disks without partitions, and save to DISK_LIST
+lsblk -dno NAME,SIZE,TYPE | while read -r name size type; do
+  if [ "$type" = "disk" ]; then
+    child_count=$(lsblk -lno NAME "/dev/$name" 2>/dev/null | wc -l)
+    if [ "$child_count" -eq 1 ]; then
+      printf '%s %s\n' "/dev/$name" "$size"
+    fi
+  fi
+done >"$DISK_LIST"
+
+# Check if any unpartitioned disks were found and prompt the user to select one
+if [ ! -s "$DISK_LIST" ]; then
+  echo "No unpartitioned disks found. Attach a new disk and try again." >&2
+  exit 1
+fi
+
+# Display the list of available disks and prompt for selection
+echo "Available unpartitioned disks:"
+i=1
+while IFS=' ' read -r disk size; do
+  printf '  %d) %s  (%s)\n' "$i" "$disk" "$size"
+  i=$((i + 1))
+done <"$DISK_LIST"
+TOTAL=$((i - 1))
+
+# Prompt the user to select a disk by number
+printf 'Select disk [1-%d]: ' "$TOTAL"
+read -r SEL
+
+# Validate the user's selection
+case "$SEL" in
+'' | *[!0-9]*)
+  echo "Error: '$SEL' is not a valid number" >&2
+  exit 1
+  ;;
+esac
+if [ "$SEL" -lt 1 ] || [ "$SEL" -gt "$TOTAL" ]; then
+  echo "Error: selection must be between 1 and $TOTAL" >&2
+  exit 1
+fi
+
+# Read the selected disk and its size from DISK_LIST
+DISK=$(awk -v n="$SEL" 'NR==n{print $1}' "$DISK_LIST")
+DISK_SIZE=$(awk -v n="$SEL" 'NR==n{print $2}' "$DISK_LIST")
+
+# Prompt the user for a mount point and validate it
+printf 'Mount point (e.g. /mnt/data, /data, /srv/storage): '
+read -r MOUNT_POINT
+
+# Validate that the mount point is an absolute path starting with '/'
+case "$MOUNT_POINT" in
+/*) ;;
+*)
+  echo "Error: mount point must be an absolute path starting with '/'" >&2
+  exit 1
+  ;;
+esac
+
+# Check if the mount point is already in use
+if grep -qs " $MOUNT_POINT " /proc/mounts; then
+  echo "Error: '$MOUNT_POINT' is already in use as a mount point" >&2
+  exit 1
+fi
+
+# Display a summary of the selected disk and mount point, and ask for confirmation
+echo ""
+echo "=== Summary ==="
+printf 'Disk:         %s (%s)\n' "$DISK" "$DISK_SIZE"
+printf 'Filesystem:   xfs\n'
+printf 'Mount point:  %s\n' "$MOUNT_POINT"
+echo ""
+printf 'WARNING: This will ERASE ALL DATA on %s.\n' "$DISK"
+printf 'Proceed? [y/N] '
+read -r reply
+case "$reply" in
+[Yy]) ;;
+*)
+  echo "Aborted."
+  exit 0
+  ;;
+esac
+
+# Create a GPT partition table on the selected disk, create a single partition, and format it with XFS
+echo ""
+echo "Creating GPT partition table on $DISK..."
+sudo parted -s "$DISK" mklabel gpt
+sudo parted -s "$DISK" mkpart data 1MiB 100%
+sudo partprobe "$DISK"
+sudo udevadm settle
+
+# Find the name of the new partition (e.g. /dev/sdb1) by listing the partitions on the disk and filtering out the disk itself
+PART_NAME=$(lsblk -lno NAME "$DISK" | grep -v "^$(basename "$DISK")$" | head -n 1)
+if [ -z "$PART_NAME" ]; then
+  echo "Error: could not find new partition on $DISK" >&2
+  exit 1
+fi
+PARTITION="/dev/$PART_NAME"
+
+# Wait for the partition to be recognized by the system
+echo "Formatting $PARTITION with XFS..."
+sudo mkfs.xfs "$PARTITION"
+
+# Mount the new partition at the specified mount point and add an entry to /etc/fstab for persistence across reboots
+echo "Mounting $PARTITION at $MOUNT_POINT..."
+sudo mkdir -p "$MOUNT_POINT"
+sudo mount "$PARTITION" "$MOUNT_POINT"
+
+# Get the UUID of the new partition and add an entry to /etc/fstab
+UUID=$(sudo blkid -s UUID -o value "$PARTITION")
+if [ -z "$UUID" ]; then
+  echo "Error: could not read UUID of $PARTITION" >&2
+  exit 1
+fi
+echo "UUID=$UUID $MOUNT_POINT xfs defaults 0 0" | sudo tee -a /etc/fstab >/dev/null
+echo "Added to /etc/fstab (UUID=$UUID)"
+
+# Display the status of the new disk, including the partition layout, mount point, and fstab entry
+echo ""
+echo "=== Disk Status ==="
+lsblk "$DISK"
+echo ""
+df -h "$MOUNT_POINT"
+echo ""
+echo "fstab entry:"
+grep "UUID=$UUID" /etc/fstab
+echo ""
+echo "Done. $PARTITION is mounted at $MOUNT_POINT and will persist across reboots."

--- a/scripts/rhel/setup-existing-disk.sh
+++ b/scripts/rhel/setup-existing-disk.sh
@@ -1,0 +1,138 @@
+#!/bin/sh
+# Prompts to select a partition that already has a filesystem but is not
+# currently mounted, mounts it at a user-specified path, and adds a fstab entry
+# for persistence across reboots.
+# Usage: sudo sh setup-existing-disk.sh
+
+set -e
+
+# Create a temporary file to store mountable partitions.
+PART_LIST=$(mktemp)
+trap 'rm -f "$PART_LIST"' EXIT
+
+# List partitions with filesystems that are currently not mounted.
+lsblk -lnpo NAME,SIZE,TYPE,FSTYPE | while read -r part size type fstype; do
+  if [ "$type" = "part" ] && [ -n "$fstype" ]; then
+    if grep -qs "^$part " /proc/mounts; then
+      continue
+    fi
+
+    uuid=$(sudo blkid -s UUID -o value "$part" 2>/dev/null || true)
+    if [ -n "$uuid" ]; then
+      printf '%s %s %s %s\n' "$part" "$size" "$fstype" "$uuid"
+    fi
+  fi
+done >"$PART_LIST"
+
+# Check if any eligible partitions were found.
+if [ ! -s "$PART_LIST" ]; then
+  echo "No unmounted partitions with an existing filesystem were found." >&2
+  exit 1
+fi
+
+# Display the list of available partitions and prompt for selection.
+echo "Available unmounted partitions with filesystems:"
+i=1
+while IFS=' ' read -r part size fstype uuid; do
+  printf '  %d) %s  (%s, %s, UUID=%s)\n' "$i" "$part" "$size" "$fstype" "$uuid"
+  i=$((i + 1))
+done <"$PART_LIST"
+TOTAL=$((i - 1))
+
+printf 'Select partition [1-%d]: ' "$TOTAL"
+read -r SEL
+
+# Validate the selected index.
+case "$SEL" in
+'' | *[!0-9]*)
+  echo "Error: '$SEL' is not a valid number" >&2
+  exit 1
+  ;;
+esac
+if [ "$SEL" -lt 1 ] || [ "$SEL" -gt "$TOTAL" ]; then
+  echo "Error: selection must be between 1 and $TOTAL" >&2
+  exit 1
+fi
+
+# Read selected partition details.
+PARTITION=$(awk -v n="$SEL" 'NR==n{print $1}' "$PART_LIST")
+PART_SIZE=$(awk -v n="$SEL" 'NR==n{print $2}' "$PART_LIST")
+FS_TYPE=$(awk -v n="$SEL" 'NR==n{print $3}' "$PART_LIST")
+UUID=$(awk -v n="$SEL" 'NR==n{print $4}' "$PART_LIST")
+
+# Ensure the partition still exists.
+if [ ! -b "$PARTITION" ]; then
+  echo "Error: selected partition '$PARTITION' is no longer available" >&2
+  exit 1
+fi
+
+# Abort if a matching fstab entry already exists.
+if grep -qs "^[^#].*UUID=${UUID}[[:space:]]" /etc/fstab; then
+  echo "Error: /etc/fstab already contains an entry for UUID=$UUID" >&2
+  exit 1
+fi
+if grep -qs "^[^#]*[[:space:]]${PARTITION}[[:space:]]" /etc/fstab; then
+  echo "Error: /etc/fstab already contains an entry for $PARTITION" >&2
+  exit 1
+fi
+
+# Prompt for mount point and validate.
+printf 'Mount point (e.g. /mnt/data, /data, /srv/storage): '
+read -r MOUNT_POINT
+
+case "$MOUNT_POINT" in
+/*) ;;
+*)
+  echo "Error: mount point must be an absolute path starting with '/'" >&2
+  exit 1
+  ;;
+esac
+
+if grep -qs " $MOUNT_POINT " /proc/mounts; then
+  echo "Error: '$MOUNT_POINT' is already in use as a mount point" >&2
+  exit 1
+fi
+if grep -qs "^[^#].*[[:space:]]${MOUNT_POINT}[[:space:]]" /etc/fstab; then
+  echo "Error: /etc/fstab already contains an entry for mount point '$MOUNT_POINT'" >&2
+  exit 1
+fi
+
+# Display summary and require confirmation before mounting.
+echo ""
+echo "=== Summary ==="
+printf 'Partition:    %s (%s)\n' "$PARTITION" "$PART_SIZE"
+printf 'Filesystem:   %s\n' "$FS_TYPE"
+printf 'UUID:         %s\n' "$UUID"
+printf 'Mount point:  %s\n' "$MOUNT_POINT"
+echo ""
+printf 'This will mount %s without formatting or erasing data.\n' "$PARTITION"
+printf 'Proceed? [y/N] '
+read -r reply
+case "$reply" in
+[Yy]) ;;
+*)
+  echo "Aborted."
+  exit 0
+  ;;
+esac
+
+# Mount the selected partition and persist in fstab.
+echo ""
+echo "Mounting $PARTITION at $MOUNT_POINT..."
+sudo mkdir -p "$MOUNT_POINT"
+sudo mount -t "$FS_TYPE" "$PARTITION" "$MOUNT_POINT"
+
+echo "UUID=$UUID $MOUNT_POINT $FS_TYPE defaults 0 0" | sudo tee -a /etc/fstab >/dev/null
+echo "Added to /etc/fstab (UUID=$UUID)"
+
+# Display status output after mounting.
+echo ""
+echo "=== Disk Status ==="
+lsblk "$PARTITION"
+echo ""
+df -h "$MOUNT_POINT"
+echo ""
+echo "fstab entry:"
+grep "UUID=$UUID" /etc/fstab
+echo ""
+echo "Done. $PARTITION is mounted at $MOUNT_POINT and will persist across reboots."

--- a/scripts/rhel/setup-new-disk.sh
+++ b/scripts/rhel/setup-new-disk.sh
@@ -2,7 +2,7 @@
 # Prompts to select an unpartitioned disk, creates a GPT partition with XFS
 # filesystem, mounts it at a user-specified path, and adds a fstab entry for
 # persistence across reboots.
-# Usage: sudo sh setup-disk.sh
+# Usage: sudo sh setup-new-disk.sh
 
 set -e
 


### PR DESCRIPTION
Introduce scripts for automated disk partitioning and mounting. The `setup-new-disk.sh` script creates a new partition on unpartitioned disks, while `setup-existing-disk.sh` mounts existing partitions that are not currently in use. Both scripts ensure persistence across reboots by updating `/etc/fstab`.