### PR TITLE
Fix MinIO installation scripts for RHEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ sudo sh scripts/rhel/setup-postgresql.sh
 
 **Location:** `scripts/rhel/setup-minio.sh`
 
-Installs MinIO AIStor server (self-hosted S3-compatible object storage) on a RHEL system, configures it as a systemd service, and validates the installation.
+Installs MinIO server (self-hosted S3-compatible object storage) on a RHEL system, configures it as a systemd service, and validates the installation.
 
 **What it does:**
 
@@ -202,14 +202,14 @@ Installs MinIO AIStor server (self-hosted S3-compatible object storage) on a RHE
 - Prompts for the admin username (default: `minioadmin`) and password (input is hidden; confirmation required; minimum 8 characters)
 - Displays an installation summary and requires explicit `[y/N]` confirmation before any changes
 - Updates and upgrades all system packages via `dnf`
-- Downloads and installs the latest MinIO AIStor RPM from `dl.min.io/aistor` for the detected architecture
+- Downloads and installs the latest MinIO community RPM from `dl.min.io/server/minio` for the detected architecture
 - Creates the data directory if it does not exist and sets ownership to `minio-user:minio-user`
 - Writes `/etc/default/minio` with `MINIO_VOLUMES`, `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD`, and `MINIO_CONSOLE_ADDRESS=":9001"` — prompts before overwriting if the file already exists
 - Opens ports 9000 (API) and 9001 (Console) via `firewall-cmd` if `firewalld` is active
 - Enables and starts the `minio` systemd service
-- Downloads the `mc` (MinIO Client) binary from `dl.min.io/aistor` and installs it to `/usr/local/bin/mc`
+- Downloads the `mc` (MinIO Client) binary from `dl.min.io/client/mc` and installs it to `/usr/local/bin/mc`
 - Waits for the MinIO health endpoint to respond, then validates with `mc admin info`
-- Prints the API endpoint, Console URL, and instructions to register a free AIStor license
+- Prints the API endpoint, Console URL, and service management commands
 
 **Usage:**
 
@@ -229,7 +229,7 @@ sudo sh scripts/rhel/setup-minio.sh
 - **Docker group membership** — `setup-docker.sh` accepts a required `<username>` argument and adds that user to the `docker` group so Docker commands can be run without `sudo`. You may need to log out and back in for this to take effect in new terminal sessions.
 - **daemon.json prompt** — if `/etc/docker/daemon.json` already exists when `setup-docker.sh` is run, the script will display the current contents and ask whether to overwrite it. Answering `N` skips the update and leaves the existing configuration in place.
 - **System update on every run** — both scripts begin with a full `dnf update && dnf upgrade`, so they may take several minutes on a freshly provisioned system.
-- **AIStor free license** — `setup-minio.sh` installs MinIO AIStor, which requires a free license registration before S3 operations are available. After installation, run `mc license register minio-local` to register. Single-node single-drive deployments qualify for the free tier.
+- **MinIO community edition** — `setup-minio.sh` installs the open-source community MinIO server (`AGPL-3.0`). No license registration is required.
 
 ## License
 

--- a/scripts/rhel/setup-minio.sh
+++ b/scripts/rhel/setup-minio.sh
@@ -6,6 +6,11 @@ if [ "$(id -u)" -ne 0 ]; then
   exit 1
 fi
 
+# sudo's secure_path on RHEL omits /usr/local/bin; ensure it is present so that
+# the minio and mc binaries installed there are reachable throughout the script.
+PATH="/usr/local/bin:/usr/local/sbin:$PATH"
+export PATH
+
 if [ ! -f /etc/os-release ]; then
   echo "Error: /etc/os-release not found — this script requires a RHEL-compatible system" >&2
   exit 1

--- a/scripts/rhel/setup-minio.sh
+++ b/scripts/rhel/setup-minio.sh
@@ -115,16 +115,13 @@ fi
 
 # --- Installation summary ---
 echo ""
-echo "=== MinIO AIStor Installation Summary ==="
+echo "=== MinIO Installation Summary ==="
 printf 'RHEL version:    %s\n' "$RHEL_MAJOR"
 printf 'Architecture:    %s\n' "$ARCH_RAW"
 printf 'Data directory:  %s\n' "$DATA_DIR"
 printf 'Admin user:      %s\n' "$ROOT_USER"
 printf 'API port:        9000\n'
 printf 'Console port:    9001\n'
-echo ""
-echo "NOTE: A free AIStor license must be registered after install"
-echo "      to enable S3 operations. Run: mc license register minio-local"
 echo ""
 
 printf 'Proceed with installation? [y/N] '
@@ -143,16 +140,16 @@ echo "Updating system packages..."
 sudo dnf -y update
 sudo dnf -y upgrade
 
-# --- Download and install MinIO AIStor RPM ---
+# --- Download and install MinIO RPM ---
 RPM_FILE=$(mktemp /tmp/minio-XXXXXX.rpm)
 trap 'rm -f "$RPM_FILE"' EXIT
 
-RPM_URL="https://dl.min.io/aistor/minio/release/linux-${ARCH}/minio.rpm"
-echo "Downloading MinIO AIStor (linux-${ARCH})..."
+RPM_URL="https://dl.min.io/server/minio/release/linux-${ARCH}/minio.rpm"
+echo "Downloading MinIO (linux-${ARCH})..."
 curl --fail --silent --show-error --location --progress-bar \
   "$RPM_URL" --output "$RPM_FILE"
 
-echo "Installing MinIO AIStor RPM..."
+echo "Installing MinIO RPM..."
 sudo dnf -y install "$RPM_FILE"
 
 echo "Installed: $(minio --version)"
@@ -184,8 +181,7 @@ fi
 
 if [ "$WRITE_ENV" -eq 1 ]; then
   {
-    printf '# MinIO AIStor environment configuration\n'
-    printf '# See: https://docs.min.io/enterprise/aistor-object-store/\n'
+    printf '# MinIO environment configuration\n'
     printf '\n'
     printf '# Storage backend\n'
     printf 'MINIO_VOLUMES="%s"\n' "$DATA_DIR"
@@ -196,9 +192,6 @@ if [ "$WRITE_ENV" -eq 1 ]; then
     printf '\n'
     printf '# Fix the web console on port 9001\n'
     printf 'MINIO_CONSOLE_ADDRESS=":9001"\n'
-    printf '\n'
-    printf '# AIStor license (register after install: mc license register minio-local)\n'
-    printf '# MINIO_LICENSE="/opt/minio/minio.license"\n'
   } | sudo tee /etc/default/minio >/dev/null
   echo "/etc/default/minio written."
 fi
@@ -231,7 +224,7 @@ fi
 MC_FILE=$(mktemp /tmp/mc-XXXXXX)
 trap 'rm -f "$RPM_FILE" "$MC_FILE"' EXIT
 
-MC_URL="https://dl.min.io/aistor/mc/release/linux-${ARCH}/mc"
+MC_URL="https://dl.min.io/client/mc/release/linux-${ARCH}/mc"
 echo "Downloading mc client (linux-${ARCH})..."
 curl --fail --silent --show-error --location --progress-bar \
   "$MC_URL" --output "$MC_FILE"
@@ -262,7 +255,7 @@ fi
 mc alias set minio-local "http://127.0.0.1:9000" "$ROOT_USER" "$ROOT_PASSWORD" >/dev/null
 
 if mc admin info minio-local >/dev/null 2>&1; then
-  echo "MinIO AIStor is healthy and accepting admin commands."
+  echo "MinIO is healthy and accepting admin commands."
 else
   echo "Warning: mc admin info failed — server may still be initializing." >&2
   echo "Run manually: mc admin info minio-local" >&2
@@ -271,13 +264,11 @@ fi
 # --- Post-install summary ---
 SERVER_IP=$(hostname -I | awk '{print $1}')
 echo ""
-echo "=== MinIO AIStor Installation Complete ==="
+echo "=== MinIO Installation Complete ==="
 printf 'API endpoint:    http://%s:9000\n' "$SERVER_IP"
 printf 'Console URL:     http://%s:9001\n' "$SERVER_IP"
 printf 'Admin user:      %s\n' "$ROOT_USER"
 printf 'Data directory:  %s\n' "$DATA_DIR"
 echo ""
-echo "IMPORTANT: S3 operations are blocked until a free license is registered."
-echo "  Register now:   mc license register minio-local"
 echo "  Service logs:   journalctl -u minio"
 echo "  Service status: systemctl status minio"


### PR DESCRIPTION
Update the MinIO installation scripts to prepend `/usr/local/bin` to the PATH for compatibility with sudo's secure_path on RHEL. Switch to the community OSS edition of MinIO, removing the license registration requirement. Adjust installation messages and URLs accordingly.