### PR TITLE
Add setup script for Redis installation on RHEL

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ A collection of shell scripts for provisioning and configuring Red Hat Enterpris
   - [setup-existing-disk.sh](#setup-existing-disksh)
   - [setup-postgresql.sh](#setup-postgresqlsh)
   - [setup-minio.sh](#setup-miniosh)
+  - [setup-redis.sh](#setup-redissh)
 - [Notes](#notes)
 - [License](#license)
 
@@ -223,6 +224,38 @@ sudo sh scripts/rhel/setup-minio.sh
 > curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-minio.sh -o /tmp/setup-minio.sh && sudo sh /tmp/setup-minio.sh
 > ```
 
+### setup-redis.sh
+
+**Location:** `scripts/rhel/setup-redis.sh`
+
+Installs the latest stable Redis server from the official Redis repository on a RHEL system, configures it for network access with password authentication, and validates the installation.
+
+**What it does:**
+
+- Detects the RHEL major version (8 or 9) at runtime; exits with an error on unsupported versions
+- Prompts for a Redis password (input is hidden; confirmation required; minimum 8 characters; no spaces or `#` characters)
+- Displays an installation summary and requires explicit `[y/N]` confirmation before any changes
+- Updates and upgrades all system packages via `dnf`
+- Imports the official Redis GPG key from `packages.redis.io`
+- Writes `/etc/yum.repos.d/redis.repo` pointing to the official Redis repository — prompts before overwriting if the file already exists
+- Installs the `redis` package from the official Redis repository
+- Configures `/etc/redis/redis.conf` to bind on all interfaces (`0.0.0.0`) and sets `requirepass` to the provided password
+- Opens port 6379 via `firewall-cmd` if `firewalld` is active; prints a manual reminder otherwise
+- Enables and starts the `redis` systemd service
+- Validates the installation with `redis-cli ping` and prints the server endpoint
+
+**Usage:**
+
+```bash
+sudo sh scripts/rhel/setup-redis.sh
+```
+
+> **Note:** This script is fully interactive — it reads from the terminal. Piping it from `curl` will break the prompts. Download it first, then run it:
+>
+> ```bash
+> curl -fsSL https://raw.githubusercontent.com/patrickquijano/server-shell-scripts/main/scripts/rhel/setup-redis.sh -o /tmp/setup-redis.sh && sudo sh /tmp/setup-redis.sh
+> ```
+
 ## Notes
 
 - **Both scripts are independent and complementary.** Run both to get a fully configured Docker host with automatic system updates.
@@ -230,6 +263,7 @@ sudo sh scripts/rhel/setup-minio.sh
 - **daemon.json prompt** — if `/etc/docker/daemon.json` already exists when `setup-docker.sh` is run, the script will display the current contents and ask whether to overwrite it. Answering `N` skips the update and leaves the existing configuration in place.
 - **System update on every run** — both scripts begin with a full `dnf update && dnf upgrade`, so they may take several minutes on a freshly provisioned system.
 - **MinIO community edition** — `setup-minio.sh` installs the open-source community MinIO server (`AGPL-3.0`). No license registration is required.
+- **Redis RHEL compatibility** — `setup-redis.sh` uses the official Redis repository (`packages.redis.io`) which supports RHEL 8 and 9 only. RHEL 10 is not yet supported by the upstream Redis RPM repository.
 
 ## License
 

--- a/scripts/rhel/setup-redis.sh
+++ b/scripts/rhel/setup-redis.sh
@@ -1,0 +1,214 @@
+#!/bin/sh
+set -e
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "Error: this script must be run as root (use sudo)" >&2
+  exit 1
+fi
+
+if [ ! -f /etc/os-release ]; then
+  echo "Error: /etc/os-release not found — this script requires a RHEL-compatible system" >&2
+  exit 1
+fi
+
+# shellcheck disable=SC1091
+RHEL_MAJOR=$(. /etc/os-release && printf '%s' "$VERSION_ID" | cut -d. -f1)
+
+case "$RHEL_MAJOR" in
+  8|9) ;;
+  *)
+    echo "Error: unsupported RHEL major version '$RHEL_MAJOR'" >&2
+    echo "  The official Redis repository (packages.redis.io) supports RHEL 8 and 9 only." >&2
+    exit 1
+    ;;
+esac
+
+# --- Redis password ---
+if [ -t 0 ]; then
+  stty -echo
+fi
+
+printf 'Redis password (min 8 chars, no spaces, no #): '
+read -r REDIS_PASSWORD
+printf '\n'
+
+printf 'Confirm password: '
+read -r REDIS_PASSWORD_CONFIRM
+printf '\n'
+
+if [ -t 0 ]; then
+  stty echo
+fi
+
+if [ -z "$REDIS_PASSWORD" ]; then
+  echo "Error: password cannot be empty" >&2
+  exit 1
+fi
+
+PW_LEN=$(printf '%s' "$REDIS_PASSWORD" | wc -c | tr -d ' \t')
+if [ "$PW_LEN" -lt 8 ]; then
+  echo "Error: password must be at least 8 characters" >&2
+  exit 1
+fi
+
+case "$REDIS_PASSWORD" in
+  *' '*)
+    echo "Error: password must not contain spaces" >&2
+    exit 1
+    ;;
+esac
+
+case "$REDIS_PASSWORD" in
+  *'#'*)
+    echo "Error: password must not contain '#'" >&2
+    exit 1
+    ;;
+esac
+
+if [ "$REDIS_PASSWORD" != "$REDIS_PASSWORD_CONFIRM" ]; then
+  echo "Error: passwords do not match" >&2
+  exit 1
+fi
+
+# --- Installation summary ---
+echo ""
+echo "=== Redis Installation Summary ==="
+printf 'RHEL version:   %s\n' "$RHEL_MAJOR"
+printf 'Repository:     packages.redis.io/rpm/rockylinux%s\n' "$RHEL_MAJOR"
+printf 'Bind address:   0.0.0.0\n'
+printf 'Port:           6379\n'
+echo ""
+
+printf 'Proceed with installation? [y/N] '
+read -r CONFIRM
+case "$CONFIRM" in
+  [Yy]) ;;
+  *)
+    echo "Aborted."
+    exit 0
+    ;;
+esac
+echo ""
+
+# --- System update ---
+echo "==> Updating system packages..."
+dnf -y update
+dnf -y upgrade
+
+# --- Import Redis GPG key ---
+echo ""
+echo "==> Importing Redis GPG key..."
+KEY_FILE=$(mktemp /tmp/redis-key-XXXXXX.gpg)
+trap 'rm -f "$KEY_FILE"' EXIT
+
+curl --fail --silent --show-error --location \
+  "https://packages.redis.io/gpg" --output "$KEY_FILE"
+rpm --import "$KEY_FILE"
+echo "Redis GPG key imported."
+
+# --- Write /etc/yum.repos.d/redis.repo ---
+echo ""
+echo "==> Configuring Redis repository..."
+WRITE_REPO=1
+if [ -f /etc/yum.repos.d/redis.repo ]; then
+  echo "Existing /etc/yum.repos.d/redis.repo:"
+  cat /etc/yum.repos.d/redis.repo
+  printf 'Overwrite? [y/N] '
+  read -r REPLY
+  case "$REPLY" in
+    [Yy]) ;;
+    *)
+      echo "Skipping /etc/yum.repos.d/redis.repo update."
+      WRITE_REPO=0
+      ;;
+  esac
+fi
+
+if [ "$WRITE_REPO" -eq 1 ]; then
+  tee /etc/yum.repos.d/redis.repo >/dev/null <<EOF
+[Redis]
+name=Redis
+baseurl=http://packages.redis.io/rpm/rockylinux${RHEL_MAJOR}
+enabled=1
+gpgcheck=1
+EOF
+  echo "/etc/yum.repos.d/redis.repo written."
+fi
+
+# --- Install redis ---
+echo ""
+echo "==> Installing Redis..."
+dnf -y install redis
+echo "Installed: $(redis-server --version)"
+
+# --- Configure /etc/redis/redis.conf ---
+echo ""
+echo "==> Configuring /etc/redis/redis.conf..."
+
+CONF="/etc/redis/redis.conf"
+
+if [ ! -f "$CONF" ]; then
+  echo "Error: $CONF not found after installation" >&2
+  exit 1
+fi
+
+# Set bind to 0.0.0.0 (all interfaces)
+if grep -q '^bind ' "$CONF"; then
+  sed -i 's/^bind .*/bind 0.0.0.0/' "$CONF"
+else
+  printf 'bind 0.0.0.0\n' | tee -a "$CONF" >/dev/null
+fi
+echo "bind set to 0.0.0.0"
+
+# Set requirepass (comment out any existing, then append)
+sed -i 's/^requirepass/# requirepass/' "$CONF"
+printf 'requirepass %s\n' "$REDIS_PASSWORD" | tee -a "$CONF" >/dev/null
+echo "requirepass configured."
+
+# --- Firewall ---
+echo ""
+if systemctl is-active --quiet firewalld; then
+  echo "==> Configuring firewall for Redis..."
+  firewall-cmd --permanent --add-port=6379/tcp
+  firewall-cmd --reload
+  echo "Firewall: opened port 6379/tcp."
+else
+  echo "firewalld is not active — skipping firewall configuration."
+  echo "NOTE: Manually open port 6379/tcp if a firewall is in use."
+fi
+
+# --- Enable and start service ---
+echo ""
+echo "==> Enabling and starting redis service..."
+systemctl enable --now redis
+
+if systemctl is-active --quiet redis; then
+  echo "redis is enabled and running."
+else
+  echo "Error: failed to start redis service." >&2
+  echo "Check logs with: journalctl -u redis" >&2
+  exit 1
+fi
+
+# --- Validate ---
+echo ""
+echo "==> Validating installation..."
+if redis-cli --no-auth-warning -a "$REDIS_PASSWORD" ping | grep -q PONG; then
+  echo "Redis responded to PING with PONG — installation validated."
+else
+  echo "Error: redis-cli ping failed." >&2
+  echo "Check logs with: journalctl -u redis" >&2
+  exit 1
+fi
+
+# --- Post-install summary ---
+REDIS_VERSION=$(redis-server --version | awk '{print $3}' | sed 's/v=//')
+SERVER_IP=$(hostname -I | awk '{print $1}')
+echo ""
+echo "=== Redis Installation Complete ==="
+printf 'Version:        %s\n' "$REDIS_VERSION"
+printf 'Endpoint:       %s:6379\n' "$SERVER_IP"
+printf 'Config:         %s\n' "$CONF"
+echo ""
+echo "  Service logs:   journalctl -u redis"
+echo "  Service status: systemctl status redis"


### PR DESCRIPTION
Create a shell script to automate the installation of the latest stable Redis server on RHEL 8/9-based distributions. The script includes argument validation, prompts for user confirmation, and ensures proper configuration and service management. It adheres to repository conventions and provides clear success and error messages.

Fixes #17