### PR TITLE
Add RHEL 10 support to setup-redis.sh via AppStream fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,13 +232,12 @@ Installs the latest stable Redis server from the official Redis repository on a 
 
 **What it does:**
 
-- Detects the RHEL major version (8 or 9) at runtime; exits with an error on unsupported versions
+- Detects the RHEL major version (8, 9, or 10) at runtime; exits with an error on unsupported versions
 - Prompts for a Redis password (input is hidden; confirmation required; minimum 8 characters; no spaces or `#` characters)
 - Displays an installation summary and requires explicit `[y/N]` confirmation before any changes
 - Updates and upgrades all system packages via `dnf`
-- Imports the official Redis GPG key from `packages.redis.io`
-- Writes `/etc/yum.repos.d/redis.repo` pointing to the official Redis repository — prompts before overwriting if the file already exists
-- Installs the `redis` package from the official Redis repository
+- On RHEL 8/9: imports the official Redis GPG key from `packages.redis.io`, writes `/etc/yum.repos.d/redis.repo` — prompts before overwriting if the file already exists — and installs the latest stable `redis` package from the official Redis repository
+- On RHEL 10: installs `redis` directly from the RHEL AppStream
 - Configures `/etc/redis/redis.conf` to bind on all interfaces (`0.0.0.0`) and sets `requirepass` to the provided password
 - Opens port 6379 via `firewall-cmd` if `firewalld` is active; prints a manual reminder otherwise
 - Enables and starts the `redis` systemd service
@@ -263,7 +262,7 @@ sudo sh scripts/rhel/setup-redis.sh
 - **daemon.json prompt** — if `/etc/docker/daemon.json` already exists when `setup-docker.sh` is run, the script will display the current contents and ask whether to overwrite it. Answering `N` skips the update and leaves the existing configuration in place.
 - **System update on every run** — both scripts begin with a full `dnf update && dnf upgrade`, so they may take several minutes on a freshly provisioned system.
 - **MinIO community edition** — `setup-minio.sh` installs the open-source community MinIO server (`AGPL-3.0`). No license registration is required.
-- **Redis RHEL compatibility** — `setup-redis.sh` uses the official Redis repository (`packages.redis.io`) which supports RHEL 8 and 9 only. RHEL 10 is not yet supported by the upstream Redis RPM repository.
+- **Redis repository source** — `setup-redis.sh` uses the official Redis repository (`packages.redis.io`) on RHEL 8 and 9 for the latest stable release, and falls back to the RHEL AppStream on RHEL 10.
 
 ## License
 

--- a/scripts/rhel/setup-redis.sh
+++ b/scripts/rhel/setup-redis.sh
@@ -15,10 +15,9 @@ fi
 RHEL_MAJOR=$(. /etc/os-release && printf '%s' "$VERSION_ID" | cut -d. -f1)
 
 case "$RHEL_MAJOR" in
-  8|9) ;;
+  8|9|10) ;;
   *)
-    echo "Error: unsupported RHEL major version '$RHEL_MAJOR'" >&2
-    echo "  The official Redis repository (packages.redis.io) supports RHEL 8 and 9 only." >&2
+    echo "Error: unsupported RHEL major version '$RHEL_MAJOR' (supported: 8, 9, 10)" >&2
     exit 1
     ;;
 esac
@@ -71,10 +70,15 @@ if [ "$REDIS_PASSWORD" != "$REDIS_PASSWORD_CONFIRM" ]; then
 fi
 
 # --- Installation summary ---
+case "$RHEL_MAJOR" in
+  8|9) REPO_SOURCE="packages.redis.io/rpm/rockylinux${RHEL_MAJOR}" ;;
+  10)  REPO_SOURCE="RHEL AppStream" ;;
+esac
+
 echo ""
 echo "=== Redis Installation Summary ==="
 printf 'RHEL version:   %s\n' "$RHEL_MAJOR"
-printf 'Repository:     packages.redis.io/rpm/rockylinux%s\n' "$RHEL_MAJOR"
+printf 'Repository:     %s\n' "$REPO_SOURCE"
 printf 'Bind address:   0.0.0.0\n'
 printf 'Port:           6379\n'
 echo ""
@@ -95,50 +99,62 @@ echo "==> Updating system packages..."
 dnf -y update
 dnf -y upgrade
 
-# --- Import Redis GPG key ---
-echo ""
-echo "==> Importing Redis GPG key..."
-KEY_FILE=$(mktemp /tmp/redis-key-XXXXXX.gpg)
-trap 'rm -f "$KEY_FILE"' EXIT
+case "$RHEL_MAJOR" in
+  8|9)
+    # --- Import Redis GPG key ---
+    echo ""
+    echo "==> Importing Redis GPG key..."
+    KEY_FILE=$(mktemp /tmp/redis-key-XXXXXX.gpg)
+    trap 'rm -f "$KEY_FILE"' EXIT
 
-curl --fail --silent --show-error --location \
-  "https://packages.redis.io/gpg" --output "$KEY_FILE"
-rpm --import "$KEY_FILE"
-echo "Redis GPG key imported."
+    curl --fail --silent --show-error --location \
+      "https://packages.redis.io/gpg" --output "$KEY_FILE"
+    rpm --import "$KEY_FILE"
+    echo "Redis GPG key imported."
 
-# --- Write /etc/yum.repos.d/redis.repo ---
-echo ""
-echo "==> Configuring Redis repository..."
-WRITE_REPO=1
-if [ -f /etc/yum.repos.d/redis.repo ]; then
-  echo "Existing /etc/yum.repos.d/redis.repo:"
-  cat /etc/yum.repos.d/redis.repo
-  printf 'Overwrite? [y/N] '
-  read -r REPLY
-  case "$REPLY" in
-    [Yy]) ;;
-    *)
-      echo "Skipping /etc/yum.repos.d/redis.repo update."
-      WRITE_REPO=0
-      ;;
-  esac
-fi
+    # --- Write /etc/yum.repos.d/redis.repo ---
+    echo ""
+    echo "==> Configuring Redis repository..."
+    WRITE_REPO=1
+    if [ -f /etc/yum.repos.d/redis.repo ]; then
+      echo "Existing /etc/yum.repos.d/redis.repo:"
+      cat /etc/yum.repos.d/redis.repo
+      printf 'Overwrite? [y/N] '
+      read -r REPLY
+      case "$REPLY" in
+        [Yy]) ;;
+        *)
+          echo "Skipping /etc/yum.repos.d/redis.repo update."
+          WRITE_REPO=0
+          ;;
+      esac
+    fi
 
-if [ "$WRITE_REPO" -eq 1 ]; then
-  tee /etc/yum.repos.d/redis.repo >/dev/null <<EOF
+    if [ "$WRITE_REPO" -eq 1 ]; then
+      tee /etc/yum.repos.d/redis.repo >/dev/null <<EOF
 [Redis]
 name=Redis
 baseurl=http://packages.redis.io/rpm/rockylinux${RHEL_MAJOR}
 enabled=1
 gpgcheck=1
 EOF
-  echo "/etc/yum.repos.d/redis.repo written."
-fi
+      echo "/etc/yum.repos.d/redis.repo written."
+    fi
 
-# --- Install redis ---
-echo ""
-echo "==> Installing Redis..."
-dnf -y install redis
+    # --- Install redis ---
+    echo ""
+    echo "==> Installing Redis..."
+    dnf -y install redis
+    ;;
+
+  10)
+    # --- Install redis from AppStream ---
+    echo ""
+    echo "==> Installing Redis from AppStream..."
+    dnf -y install redis
+    ;;
+esac
+
 echo "Installed: $(redis-server --version)"
 
 # --- Configure /etc/redis/redis.conf ---


### PR DESCRIPTION
Enhance the setup-redis.sh script to support RHEL 10 by falling back to the RHEL AppStream for Redis installation, while maintaining support for RHEL 8 and 9 through the official Redis repository. Update error messages and installation summaries accordingly.