### PR TITLE
Fix Redis installation on RHEL 10 by using Valkey from AppStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ Installs the latest stable Redis server from the official Redis repository on a 
 - Displays an installation summary and requires explicit `[y/N]` confirmation before any changes
 - Updates and upgrades all system packages via `dnf`
 - On RHEL 8/9: imports the official Redis GPG key from `packages.redis.io`, writes `/etc/yum.repos.d/redis.repo` — prompts before overwriting if the file already exists — and installs the latest stable `redis` package from the official Redis repository
-- On RHEL 10: installs `redis` directly from the RHEL AppStream
+- On RHEL 10: installs `valkey` from the RHEL AppStream — Valkey is the protocol-compatible open-source Redis fork shipped in EL-10 following the Redis license change
 - Configures `/etc/redis/redis.conf` to bind on all interfaces (`0.0.0.0`) and sets `requirepass` to the provided password
 - Opens port 6379 via `firewall-cmd` if `firewalld` is active; prints a manual reminder otherwise
 - Enables and starts the `redis` systemd service
@@ -262,7 +262,7 @@ sudo sh scripts/rhel/setup-redis.sh
 - **daemon.json prompt** — if `/etc/docker/daemon.json` already exists when `setup-docker.sh` is run, the script will display the current contents and ask whether to overwrite it. Answering `N` skips the update and leaves the existing configuration in place.
 - **System update on every run** — both scripts begin with a full `dnf update && dnf upgrade`, so they may take several minutes on a freshly provisioned system.
 - **MinIO community edition** — `setup-minio.sh` installs the open-source community MinIO server (`AGPL-3.0`). No license registration is required.
-- **Redis repository source** — `setup-redis.sh` uses the official Redis repository (`packages.redis.io`) on RHEL 8 and 9 for the latest stable release, and falls back to the RHEL AppStream on RHEL 10.
+- **Redis repository source** — `setup-redis.sh` uses the official Redis repository (`packages.redis.io`) on RHEL 8 and 9 for the latest stable release. On RHEL 10, it installs `valkey` from the RHEL AppStream instead — Redis is not available on EL-10 due to a license change and was replaced by Valkey, a protocol-compatible open-source fork.
 
 ## License
 

--- a/scripts/rhel/setup-redis.sh
+++ b/scripts/rhel/setup-redis.sh
@@ -22,6 +22,25 @@ case "$RHEL_MAJOR" in
     ;;
 esac
 
+# --- Per-version service/binary/config names ---
+# RHEL 10 ships Valkey (an open-source Redis fork) instead of Redis due to
+# the Redis license change; Valkey is protocol-compatible and uses identical
+# config directives.
+case "$RHEL_MAJOR" in
+  8|9)
+    SERVICE="redis"
+    CONF="/etc/redis/redis.conf"
+    CLI="redis-cli"
+    SERVER_BIN="redis-server"
+    ;;
+  10)
+    SERVICE="valkey"
+    CONF="/etc/valkey/valkey.conf"
+    CLI="valkey-cli"
+    SERVER_BIN="valkey-server"
+    ;;
+esac
+
 # --- Redis password ---
 if [ -t 0 ]; then
   stty -echo
@@ -72,7 +91,7 @@ fi
 # --- Installation summary ---
 case "$RHEL_MAJOR" in
   8|9) REPO_SOURCE="packages.redis.io/rpm/rockylinux${RHEL_MAJOR}" ;;
-  10)  REPO_SOURCE="RHEL AppStream" ;;
+  10)  REPO_SOURCE="RHEL AppStream (valkey)" ;;
 esac
 
 echo ""
@@ -148,20 +167,18 @@ EOF
     ;;
 
   10)
-    # --- Install redis from AppStream ---
+    # --- Install valkey from AppStream ---
     echo ""
-    echo "==> Installing Redis from AppStream..."
-    dnf -y install redis
+    echo "==> Installing Valkey from AppStream..."
+    dnf -y install valkey
     ;;
 esac
 
-echo "Installed: $(redis-server --version)"
+echo "Installed: $($SERVER_BIN --version)"
 
-# --- Configure /etc/redis/redis.conf ---
+# --- Configure $CONF ---
 echo ""
-echo "==> Configuring /etc/redis/redis.conf..."
-
-CONF="/etc/redis/redis.conf"
+echo "==> Configuring $CONF..."
 
 if [ ! -f "$CONF" ]; then
   echo "Error: $CONF not found after installation" >&2
@@ -195,30 +212,30 @@ fi
 
 # --- Enable and start service ---
 echo ""
-echo "==> Enabling and starting redis service..."
-systemctl enable --now redis
+echo "==> Enabling and starting $SERVICE service..."
+systemctl enable --now "$SERVICE"
 
-if systemctl is-active --quiet redis; then
-  echo "redis is enabled and running."
+if systemctl is-active --quiet "$SERVICE"; then
+  echo "$SERVICE is enabled and running."
 else
-  echo "Error: failed to start redis service." >&2
-  echo "Check logs with: journalctl -u redis" >&2
+  echo "Error: failed to start $SERVICE service." >&2
+  echo "Check logs with: journalctl -u $SERVICE" >&2
   exit 1
 fi
 
 # --- Validate ---
 echo ""
 echo "==> Validating installation..."
-if redis-cli --no-auth-warning -a "$REDIS_PASSWORD" ping | grep -q PONG; then
-  echo "Redis responded to PING with PONG — installation validated."
+if "$CLI" --no-auth-warning -a "$REDIS_PASSWORD" ping | grep -q PONG; then
+  echo "$SERVICE responded to PING with PONG — installation validated."
 else
-  echo "Error: redis-cli ping failed." >&2
-  echo "Check logs with: journalctl -u redis" >&2
+  echo "Error: $CLI ping failed." >&2
+  echo "Check logs with: journalctl -u $SERVICE" >&2
   exit 1
 fi
 
 # --- Post-install summary ---
-REDIS_VERSION=$(redis-server --version | awk '{print $3}' | sed 's/v=//')
+REDIS_VERSION=$($SERVER_BIN --version | awk '{print $3}' | sed 's/v=//')
 SERVER_IP=$(hostname -I | awk '{print $1}')
 echo ""
 echo "=== Redis Installation Complete ==="
@@ -226,5 +243,5 @@ printf 'Version:        %s\n' "$REDIS_VERSION"
 printf 'Endpoint:       %s:6379\n' "$SERVER_IP"
 printf 'Config:         %s\n' "$CONF"
 echo ""
-echo "  Service logs:   journalctl -u redis"
-echo "  Service status: systemctl status redis"
+echo "  Service logs:   journalctl -u $SERVICE"
+echo "  Service status: systemctl status $SERVICE"


### PR DESCRIPTION
Switch the installation process for RHEL 10 to use Valkey, an open-source Redis fork, due to Redis's unavailability following a license change. Update service names, configuration paths, and CLI tools accordingly throughout the script.